### PR TITLE
Added the class definition for ego_renewable_feeding

### DIFF
--- a/egoio/db_tables/model_draft.py
+++ b/egoio/db_tables/model_draft.py
@@ -3704,6 +3704,16 @@ t_ego_res_powerplant_costdat_gid = Table(
     schema='model_draft'
 )
 
+class EgoRenewableFeedin(Base):
+    __tablename__ = 'ego_renewable_feedin'
+    __table_args__ = {'schema': 'model_draft'}
+
+    weather_scenario_id = Column(Integer, primary_key=True, nullable=False)
+    w_id = Column(Integer, primary_key=True, nullable=False)
+    source = Column(Text, primary_key=True, nullable=False)
+    weather_year = Column(Integer, primary_key=True, nullable=False)
+    feedin = Column(ARRAY(DOUBLE_PRECISION(precision=53)))
+    scenario = Column(Text, primary_key=True, nullable=False)
 
 class EgoScenario(Base):
     __tablename__ = 'ego_scenario'


### PR DESCRIPTION
Having created the model_draft.ego_renewable_feedin, it be used in the next eDisGo release in place of model_draft.ego_simple_feedin. The problem is that, the class definitions for ego_renewable_feeding are not yet in ego.io. We need a solution for this, possibilities are:

- Release a minor version of ego.io including the class definitions for the new table (the convention seems to be that DP and ego.io have same version numbers.)
- If the major release of DP and ego.io is planned this point would get solved
- Using a dependency link directly to the github code till the next major release of DP and ego.io
