### PR TITLE
Allow different dialects in configuration

### DIFF
--- a/egoio/tools/db.py
+++ b/egoio/tools/db.py
@@ -115,6 +115,7 @@ def get_connection_details(section):
         Used for configuration file parser language.
     """
     print('Please enter your connection details:')
+    dialect = 'psycopg2'
     username = input('Enter value for `username`: ')
     database = input('Enter value for `database`: ')
     host = input('Enter value for `host`: ')
@@ -122,6 +123,7 @@ def get_connection_details(section):
 
     cfg = cp.ConfigParser()
     cfg.add_section(section)
+    cfg.set(section, 'dialect', dialect)
     cfg.set(section, 'username', username)
     cfg.set(section, 'host', host)
     cfg.set(section, 'port', port)
@@ -226,7 +228,8 @@ def connection(filepath=None, section='oep'):
         
     # establish connection and return it
     conn = create_engine(
-        "postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}".format(
+        "postgresql+{dialect}://{user}:{password}@{host}:{port}/{db}".format(
+            dialect=cfg.get(section, 'dialect', fallback='psycopg2'),
             user=cfg.get(section, 'username'),
             password=pw,
             host=cfg.get(section, 'host'),


### PR DESCRIPTION
Up to now, psycopg2 was hardwired into ego.io. Users are now able to specify a dialect in their configuration.
If no dialect is specified, psycopg2 will be used as a fallback
Closes #58