### PR TITLE
Included aggr_weather table in supply schema (used for eGo specs)

### DIFF
--- a/egoio/db_tables/model_draft.py
+++ b/egoio/db_tables/model_draft.py
@@ -4344,17 +4344,6 @@ class EgoStorageH2AreasDe(Base):
     geom = Column(Geometry('MULTIPOLYGON', 4326), index=True)
 
 
-t_ego_supply_aggr_weather_mview = Table(
-    'ego_supply_aggr_weather_mview', metadata,
-    Column('aggr_id', BigInteger),
-    Column('w_id', BigInteger),
-    Column('scn_name', String),
-    Column('bus', BigInteger),
-    Column('row_number', BigInteger),
-    schema='model_draft'
-)
-
-
 t_ego_supply_conv_nep2035_temp = Table(
     'ego_supply_conv_nep2035_temp', metadata,
     Column('preversion', Text),

--- a/egoio/db_tables/supply.py
+++ b/egoio/db_tables/supply.py
@@ -636,6 +636,18 @@ t_ego_res_powerplant_altmark_vg_mview = Table(
 )
 
 
+class EgoAggrWeather(Base):
+    __tablename__ = 'ego_aggr_weather'
+    __table_args__ = {'schema': 'supply'}
+    
+    version = Column(Text, primary_key=True, nullable=False)
+    aggr_id = Column(BigInteger)
+    w_id = Column(BigInteger)
+    scn_name = Column(Text)
+    bus = Column(BigInteger)
+    row_number = Column(BigInteger, primary_key=True, nullable=False)
+    
+   
 class ForwindOekoRenewableCapacityPerFederalstate(Base):
     __tablename__ = 'forwind_oeko_renewable_capacity_per_federalstate'
     __table_args__ = {'schema': 'supply'}


### PR DESCRIPTION
This adjustment was necessary, because the new table ego_aggr_weather was moved to the versioned supply schema. This table is needed to allocate weather ID's to generator aggregates...