### PR TITLE
Remove upper bound for packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='egoio',
       license='GNU Affero General Public License v3.0',
       install_requires=[
           'geoalchemy2 >= 0.3.0, <= 0.4.1',
-          'sqlalchemy >= 1.0.11, <= 1.2.0',
+          'sqlalchemy >= 1.2.0',
           'keyring >= 4.0',
           'keyrings.alt',
           'psycopg2'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='egoio',
       packages=find_packages(),
       license='GNU Affero General Public License v3.0',
       install_requires=[
-          'geoalchemy2 >= 0.3.0, <= 0.4.1',
+          'geoalchemy2 >= 0.3.0',
           'sqlalchemy >= 1.2.0',
           'keyring >= 4.0',
           'keyrings.alt',


### PR DESCRIPTION
oedialect requires sqlalchemy >= 1.2.0 which would make it incompatible with ego.io for no reason