### PR TITLE
Features/connection default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Here is a template for new release sections
 ### Added
 
 ### Changed
+- set default values for database connection details to oep connection details
 
 ## [0.4.7] 2019-08-29
 

--- a/egoio/tools/db.py
+++ b/egoio/tools/db.py
@@ -116,11 +116,14 @@ def get_connection_details(section):
         Used for configuration file parser language.
     """
     print('Please enter your connection details:')
-    dialect = input('Enter input value for `dialect` (default: psycopg2): ') or 'psycopg2'
+    dialect = input('Enter input value for `dialect` (default: oedialect): ') \
+              or 'oedialect'
     username = input('Enter value for `username`: ')
-    database = input('Enter value for `database`: ')
-    host = input('Enter value for `host`: ')
-    port = input('Enter value for `port` (default: 5432): ') or '5432'
+    database = input('Enter value for `database` (default: oedb): ') or 'oedb'
+    host = input(
+        'Enter value for `host` (default: openenergy-platform.org): ') or \
+           'openenergy-platform.org'
+    port = input('Enter value for `port` (default: 80): ') or '80'
 
     cfg = cp.ConfigParser()
     cfg.add_section(section)


### PR DESCRIPTION
I think it would be helpful and convenient to have the connection details needed to use the oedialect/OEP as default values upon creation of the config.ini, which is what this PR does.